### PR TITLE
[WIP] pg_rewind datadirs sync improvement

### DIFF
--- a/src/bin/pg_rewind/filemap.h
+++ b/src/bin/pg_rewind/filemap.h
@@ -109,5 +109,6 @@ extern void process_target_wal_block_change(ForkNumber forknum,
 extern filemap_t *decide_file_actions(void);
 extern void calculate_totals(filemap_t *filemap);
 extern void print_filemap(filemap_t *filemap);
+extern void preserve_file(char *filepath);
 
 #endif							/* FILEMAP_H */

--- a/src/bin/pg_rewind/pg_rewind.c
+++ b/src/bin/pg_rewind/pg_rewind.c
@@ -405,13 +405,13 @@ main(int argc, char **argv)
 		exit(0);
 	}
 
+	/* Initialize the hash table to track the status of each file */
+	filehash_init();
+
 	findLastCheckpoint(datadir_target, divergerec, lastcommontliIndex,
 					   &chkptrec, &chkpttli, &chkptredo, restore_command);
 	pg_log_info("rewinding from last common checkpoint at %X/%X on timeline %u",
 				LSN_FORMAT_ARGS(chkptrec), chkpttli);
-
-	/* Initialize the hash table to track the status of each file */
-	filehash_init();
 
 	/*
 	 * Collect information about all files in the both data directories.


### PR DESCRIPTION
**Problem description**
If a leader that is not fast enough in archiving WAL segments (e.g. network issues, high CPU/Disk load...) fails and a replica is successfully promoted, it can be out for long enough time to let the promoted replica rotate the WAL segments that were not archived. As long as archive_mode != always (allow replica to also archive WALs) and replica (by design) doesn't send anything from previous timeline to archive on promote (except for .partial and .history files) - archive will never receive the missing files.
The only place where the WAL segments are still present is the failed leader's FS.

However when we try to revive the leader, we first run pg_rewind utility in order retrieve the missing WAL files from archive or to remove the WALs that could be generated on the old leader after the replica promoted (after the point of divergence). To our surprise, pg_rewind is quite trivial: it basically syncs the content of pg_wal directory of the old leader with the new leader's one. Including deletion of all WALs that are not present on the current leader (promoted replica). After pg_rewind finishes successfully we lost the non-archived WALs.

**Proposed solution**
Make pg_rewind to be a little bit wiser in terms of creating filemap for WALs: preserve WAL segments, which contain those potentially lost records (> the last common checkpoint and  < the point of divergence), on the target.